### PR TITLE
Feature/fix image rotation

### DIFF
--- a/app/src/main/java/com/rodrigo/deeplarva/helpers/pictureInputHelper/PictureByStorageHandler.kt
+++ b/app/src/main/java/com/rodrigo/deeplarva/helpers/pictureInputHelper/PictureByStorageHandler.kt
@@ -3,7 +3,11 @@ package com.rodrigo.deeplarva.helpers.pictureInputHelper
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.media.ExifInterface
+import android.net.Uri
 import android.provider.MediaStore
+import java.io.IOException
 
 class PictureByStorageHandler(override val activity: Activity): IPictureReceiverHandler {
     private val REQUESTCODE = 101
@@ -15,11 +19,53 @@ class PictureByStorageHandler(override val activity: Activity): IPictureReceiver
     }
     override fun getBitmap(requestCode: Int, resultCode: Int, data: Intent?): List<Bitmap> {
         if (requestCode == REQUESTCODE && resultCode == Activity.RESULT_OK){
-            val bitmap = MediaStore.Images.Media.getBitmap(activity.contentResolver, data?.data)
-            return listOf(bitmap)
+            val uri = data?.data ?: throw Exception("ERROR_GETTING_IMAGE")
+            val bitmap = MediaStore.Images.Media.getBitmap(activity.contentResolver, uri)
+
+            val filePath = getRealPathFromURI(uri)
+
+            // Corregir la orientación del bitmap
+            val correctedBitmap = correctBitmapOrientation(bitmap, filePath)
+
+            return listOf(correctedBitmap)
         }
         throw Exception("ERROR_GETTING_IMAGE")
     }
+
+    private fun getRealPathFromURI(uri: Uri): String {
+        var filePath = ""
+        val cursor = activity.contentResolver.query(uri, null, null, null, null)
+        if (cursor != null) {
+            cursor.moveToFirst()
+            val idx = cursor.getColumnIndex(MediaStore.Images.ImageColumns.DATA)
+            if (idx != -1) {
+                filePath = cursor.getString(idx)
+            }
+            cursor.close()
+        }
+        return filePath
+    }
+
+    private fun correctBitmapOrientation(bitmap: Bitmap, filePath: String): Bitmap {
+        val exif = try {
+            ExifInterface(filePath)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            return bitmap
+        }
+
+        val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+
+        val matrix = Matrix()
+        when (orientation) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
+            ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
+            ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+        }
+
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+    }
+
     override fun getRequestCode(): Int{
         return REQUESTCODE
     }


### PR DESCRIPTION
Se añadió la función para rotar como se tomó la foto y como se ve en pantalla. 
Razón:
Se entrenó con fotos del recipiente en vertical

Se usó esta foto para testear la función
Descargar imagen [IMG_20240611_121746_363.jpg](https://drive.google.com/file/d/1mI-AErSQiYCwY21cMq3r4HVY9vk3pUcj/view?usp=sharing)

Valor real de conteo: 107

Predicción sin funcion de rotar la imagen
![image](https://github.com/RodLopezDev/deep_larva_app/assets/73648482/ad00cec5-feba-43b6-b353-f6195110c5e5)

Predicción con función de rotar la imagen
![image](https://github.com/RodLopezDev/deep_larva_app/assets/73648482/06af24fa-aec7-4ec6-a0fa-95129adee902)


