### PR TITLE
Optimize/prediction algorithm

### DIFF
--- a/app/src/main/java/com/rodrigo/deeplarva/modules/prediction/BackgroundTaskPredict.kt
+++ b/app/src/main/java/com/rodrigo/deeplarva/modules/prediction/BackgroundTaskPredict.kt
@@ -110,11 +110,9 @@ class BackgroundTaskPredict(private val my: Context) {
                 bitmap,
                 splitWidth = 640,
                 splitHeight = 640,
-                overlap = 0.8f,
-                miBatchSize = 6,
-                miCustomConfidenceThreshold = 0.28F,
-                miCustomIoUThreshold = 0.80F,
-                distanceThreshold = 10.0f
+                overlap = 0.75f,
+                miCustomConfidenceThreshold = 0.60F,
+                miCustomIoUThresholdNMS = 0.3f
             )
             val endTimeMillis = System.currentTimeMillis()
             val totalTime = endTimeMillis - startTimeMillis

--- a/app/src/main/java/com/rodrigo/deeplarva/modules/prediction/Detector.kt
+++ b/app/src/main/java/com/rodrigo/deeplarva/modules/prediction/Detector.kt
@@ -80,7 +80,7 @@ class Detector(
         interpreter = null
     }
 
-    fun detect(frame: Bitmap, customConfidenceThreshold: Float, custom_IoUThreshold: Float): List<BoundingBox>? {
+    fun detect(frame: Bitmap, customConfidenceThreshold: Float): List<BoundingBox>? {
 
         var inferenceTime = SystemClock.uptimeMillis()
 
@@ -97,12 +97,12 @@ class Detector(
         val output = TensorBuffer.createFixedSize(intArrayOf(1 , numChannel, numElements), OUTPUT_IMAGE_TYPE)
         interpreter?.run(imageBuffer, output.buffer)
 
-        val bestBoxes = bestBox(output.floatArray, customConfidenceThreshold, custom_IoUThreshold)
+        val bestBoxes = bestBox(output.floatArray, customConfidenceThreshold)
 
         return bestBoxes
     }
 
-    private fun bestBox(array: FloatArray, confidenceThreshold: Float, iouThreshold: Float) : List<BoundingBox>? {
+    private fun bestBox(array: FloatArray, confidenceThreshold: Float) : List<BoundingBox>? {
 
         val boundingBoxes = mutableListOf<BoundingBox>()
 
@@ -147,45 +147,7 @@ class Detector(
 
         if (boundingBoxes.isEmpty()) return null
 
-        return applyNMS(boundingBoxes, iouThreshold)
-    }
-
-    private fun applyNMS(boxes: List<BoundingBox>, iouThreshold: Float) : MutableList<BoundingBox> {
-        val sortedBoxes = boxes.sortedByDescending { it.cnf }.toMutableList()
-        val selectedBoxes = mutableListOf<BoundingBox>()
-
-        while(sortedBoxes.isNotEmpty()) {
-            val first = sortedBoxes.first()
-            selectedBoxes.add(first)
-            sortedBoxes.remove(first)
-
-            val iterator = sortedBoxes.iterator()
-            while (iterator.hasNext()) {
-                val nextBox = iterator.next()
-                val iou = calculateIoU(first, nextBox)
-                if (iou > iouThreshold) {
-                    iterator.remove()
-                }
-            }
-        }
-
-        return selectedBoxes
-    }
-
-    private fun calculateIoU(box1: BoundingBox, box2: BoundingBox): Float {
-        val x1 = maxOf(box1.x1, box2.x1)
-        val y1 = maxOf(box1.y1, box2.y1)
-        val x2 = minOf(box1.x2, box2.x2)
-        val y2 = minOf(box1.y2, box2.y2)
-        val intersectionArea = maxOf(0F, x2 - x1) * maxOf(0F, y2 - y1)
-        val box1Area = box1.w * box1.h
-
-        val box1Area_v2 = ( box1.x2 - box1.x1) * ( box1.y2 - box1.y1)
-        val box2Area_v2 = ( box2.x2 - box2.x1) * ( box2.y2 - box2.y1)
-
-        val union = box1Area_v2 + box2Area_v2 - intersectionArea
-
-        return intersectionArea / union
+        return boundingBoxes
     }
 
     interface DetectorListener {


### PR DESCRIPTION
# Cambios
- Eliminé el batch porque no hacía diferencia en el tiempo de predicción
- Ahora se usa el nms una sola vez, cuando ya se tenga todas las predicciones en todas las imágenes recortadas.
- Mas rápido a la hora de unir las cajas delimitadoras en las predicciones
- Tambien cambié las configuraciones intersección de NMS, nivel de confianza y solape de imágenes. Son las configuraciones que dan un mejor rendimiento y son mas precisas en el conteo. 

Mejores configuraciones:
- overlap = 0.75f
- miCustomConfidenceThreshold = 0.60F
- miCustomIoUThresholdNMS = 0.3f